### PR TITLE
Set agent-instrumenter JDK to 1.8

### DIFF
--- a/agent-instrumenter/pom.xml
+++ b/agent-instrumenter/pom.xml
@@ -14,8 +14,8 @@
     </parent>
 
     <properties>
-        <maven.compiler.source>15</maven.compiler.source>
-        <maven.compiler.target>15</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <dependencies>

--- a/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/OpenTelemetryLoader.java
+++ b/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/OpenTelemetryLoader.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
+import java.util.Arrays;
 import java.util.List;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.asm.Advice;
@@ -86,13 +87,13 @@ public class OpenTelemetryLoader {
 
   public void injectClasses(File jarFile) throws IOException {
     List<Class<?>> classesToInject =
-        List.of(
+        Arrays.asList(
             BytesAndName.class,
             PreTransformer.class,
             PostTransformer.class,
             StaticInstrumenter.class);
 
-    for (var clazz : classesToInject) {
+    for (Class<?> clazz : classesToInject) {
       String[] clazzNameParts = clazz.getName().split("\\.");
       String clazzName = clazzNameParts[clazzNameParts.length - 1];
 


### PR DESCRIPTION
We need to compile agent-instrumenter contents with 1.8 be able to use the plugin with older java versions