### PR TITLE
Solve `VirtualField`-related errors

### DIFF
--- a/agent-instrumenter/pom.xml
+++ b/agent-instrumenter/pom.xml
@@ -24,6 +24,11 @@
             <artifactId>byte-buddy-dep</artifactId>
             <version>1.11.5</version>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/AgentUtils.java
+++ b/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/AgentUtils.java
@@ -11,6 +11,7 @@ import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
 
 public class AgentUtils {
 
@@ -83,6 +84,7 @@ public class AgentUtils {
     Path classPackage = Files.createDirectories(extractedAgent.resolve(path));
 
     Files.write(
-        classPackage.resolve(className), otelJarFile.getInputStream(entryToSave).readAllBytes());
+        classPackage.resolve(className),
+        IOUtils.toByteArray(otelJarFile.getInputStream(entryToSave)));
   }
 }

--- a/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/AgentUtils.java
+++ b/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/AgentUtils.java
@@ -1,0 +1,88 @@
+package agh.edu.pl.agent.instrumentation;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Enumeration;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import org.apache.commons.io.FileUtils;
+
+public class AgentUtils {
+
+  private final Path tmpDir;
+  private final Path extractedAgent;
+
+  public AgentUtils() throws IOException {
+    tmpDir = Files.createTempDirectory("tmp-class-dir");
+    extractedAgent = Files.createDirectories(tmpDir.resolve("opentelemetry-javaagent"));
+
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  try {
+                    FileUtils.deleteDirectory(tmpDir.toFile());
+                  } catch (IOException ex) {
+                    ex.printStackTrace();
+                  }
+                }));
+  }
+
+  public static Path createAgentCopy(String agentPath, String pluginResourcesPath) {
+
+    File agentFile = new File(agentPath);
+    Path newAgentName = Paths.get(agentFile.getName());
+    Path newAgentPath = Paths.get(pluginResourcesPath).resolve(newAgentName);
+
+    try {
+      return Files.copy(Paths.get(agentPath), newAgentPath, REPLACE_EXISTING);
+    } catch (IOException e) {
+      System.err.println("Could not copy agent from " + agentPath + " to " + newAgentPath);
+      e.printStackTrace();
+      System.exit(1);
+      return null;
+    }
+  }
+
+  public Path extractAgent(File agentFile) throws IOException {
+    JarFile otelJarFile = new JarFile(agentFile);
+
+    Enumeration<JarEntry> entries = otelJarFile.entries();
+
+    while (entries.hasMoreElements()) {
+
+      JarEntry entry = entries.nextElement();
+      String name = entry.getName();
+
+      String sanitizedName;
+
+      if (name.contains("inst/") && name.contains(".classdata")) {
+        sanitizedName = name.replace(".classdata", "").replace("inst/", "");
+      } else {
+        sanitizedName = name.replace(".class", "");
+      }
+
+      extractEntry(otelJarFile, entry, sanitizedName);
+    }
+
+    return extractedAgent;
+  }
+
+  private void extractEntry(JarFile otelJarFile, JarEntry entryToSave, String sanitized)
+      throws IOException {
+    int lastSlashIdx = sanitized.lastIndexOf("/");
+    String path =
+        sanitized.substring(0, lastSlashIdx).replace("/", System.getProperty("file.separator"));
+    String className = sanitized.substring(lastSlashIdx + 1) + ".class";
+
+    Path classPackage = Files.createDirectories(extractedAgent.resolve(path));
+
+    Files.write(
+        classPackage.resolve(className), otelJarFile.getInputStream(entryToSave).readAllBytes());
+  }
+}

--- a/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/OpenTelemetryLoader.java
+++ b/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/OpenTelemetryLoader.java
@@ -17,9 +17,9 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -83,8 +83,8 @@ public class OpenTelemetryLoader {
           new URLClassLoader(
               new URL[] {otelJar.toURI().toURL()}, OpenTelemetryLoader.class.getClassLoader());
 
-      String OTEL_AGENT_NAME = "io.opentelemetry.javaagent.OpenTelemetryAgent";
-      openTelemetryAgentClass = Class.forName(OTEL_AGENT_NAME, true, otelClassLoader);
+      openTelemetryAgentClass =
+          Class.forName("io.opentelemetry.javaagent.OpenTelemetryAgent", true, otelClassLoader);
       System.out.println("Loaded OpenTelemetryAgent: " + openTelemetryAgentClass);
 
       Path tmpDir = agentUtils.extractAgent(otelJar);

--- a/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/OpenTelemetryLoader.java
+++ b/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/OpenTelemetryLoader.java
@@ -5,28 +5,34 @@ import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static net.bytebuddy.matcher.ElementMatchers.isMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
+import agh.edu.pl.agent.instrumentation.advices.HelperInjectorAdvice;
 import agh.edu.pl.agent.instrumentation.advices.InstallBootstrapJarAdvice;
 import agh.edu.pl.agent.instrumentation.advices.OpenTelemetryAgentAdvices;
 import io.opentelemetry.javaagent.BytesAndName;
 import io.opentelemetry.javaagent.PostTransformer;
 import io.opentelemetry.javaagent.PreTransformer;
 import io.opentelemetry.javaagent.StaticInstrumenter;
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.util.Arrays;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.asm.Advice;
 
 public class OpenTelemetryLoader {
   public URLClassLoader otelClassLoader;
-  public Class<?> openTelemetryAgentClass;
+  private Class<?> openTelemetryAgentClass;
+  private Class<?> helperInjectorClass;
   public String otelJarPath;
-  private String pluginResourcesPath;
-  private final String OTEL_AGENT_NAME = "io.opentelemetry.javaagent.OpenTelemetryAgent";
+  private final String pluginResourcesPath;
 
   public OpenTelemetryLoader(String otelJarPath, String pluginResourcesPath) {
     this.otelJarPath = otelJarPath;
@@ -34,11 +40,10 @@ public class OpenTelemetryLoader {
   }
 
   public void instrument() {
-    loadOtel(new File(otelJarPath));
+    loadClasses(new File(otelJarPath));
     File otelJarFile = new File(otelJarPath);
-    File copyFile =
-        new File(
-            pluginResourcesPath + System.getProperty("file.separator") + otelJarFile.getName());
+    File copyFile = AgentUtils.createAgentCopy(otelJarPath, pluginResourcesPath).toFile();
+
     try {
       Files.copy(otelJarFile.toPath(), copyFile.toPath(), REPLACE_EXISTING);
     } catch (IOException exception) {
@@ -49,7 +54,9 @@ public class OpenTelemetryLoader {
     System.out.println("Copied OTEL to " + pluginResourcesPath);
     try {
       instrumentOpenTelemetryAgent(copyFile);
+      instrumentHelperInjector(copyFile);
     } catch (IOException exception) {
+      exception.printStackTrace();
       System.err.println("Problem occurred during OpenTelemetry Agent instrumentation.");
       return;
     }
@@ -61,20 +68,52 @@ public class OpenTelemetryLoader {
     }
   }
 
-  public synchronized void loadOtel(File otelJar) {
+  public synchronized void loadClasses(File otelJar) {
+    AgentUtils agentUtils = null;
+
+    try {
+      agentUtils = new AgentUtils();
+    } catch (IOException e) {
+      e.printStackTrace();
+      System.exit(1);
+    }
+
     try {
       otelClassLoader =
           new URLClassLoader(
               new URL[] {otelJar.toURI().toURL()}, OpenTelemetryLoader.class.getClassLoader());
 
+      String OTEL_AGENT_NAME = "io.opentelemetry.javaagent.OpenTelemetryAgent";
       openTelemetryAgentClass = Class.forName(OTEL_AGENT_NAME, true, otelClassLoader);
       System.out.println("Loaded OpenTelemetryAgent: " + openTelemetryAgentClass);
+
+      Path tmpDir = agentUtils.extractAgent(otelJar);
+      loadHelperInjector(tmpDir);
+      System.out.println("Loaded HelperInjector: " + helperInjectorClass);
+
     } catch (ClassNotFoundException | IOException e) {
       e.printStackTrace();
     }
   }
 
-  public void instrumentOpenTelemetryAgent(File jarFile) throws IOException {
+  private synchronized void loadHelperInjector(Path tmpDir) {
+    URL url = null;
+    try {
+      url = tmpDir.toUri().toURL();
+    } catch (MalformedURLException e) {
+      e.printStackTrace();
+    }
+    System.out.println(url);
+
+    try {
+      ClassLoader cl = new URLClassLoader(new URL[] {url});
+      helperInjectorClass = cl.loadClass("io.opentelemetry.javaagent.tooling.HelperInjector");
+    } catch (ClassNotFoundException e) {
+      e.printStackTrace();
+    }
+  }
+
+  private void instrumentOpenTelemetryAgent(File jarFile) throws IOException {
     new ByteBuddy()
         .rebase(openTelemetryAgentClass)
         .visit(Advice.to(OpenTelemetryAgentAdvices.class).on(isMethod().and(named("agentmain"))))
@@ -83,6 +122,45 @@ public class OpenTelemetryLoader {
                 .on(isMethod().and(named("installBootstrapJar"))))
         .make()
         .inject(jarFile);
+  }
+
+  // we have to inject .classdata file which is not possible through bytebuddy injection
+  private void instrumentHelperInjector(File jarFile) throws IOException {
+    byte[] helperInjectorBytes =
+        new ByteBuddy()
+            .rebase(helperInjectorClass)
+            .visit(
+                Advice.to(HelperInjectorAdvice.class)
+                    .on(isMethod().and(named("injectBootstrapClassLoader"))))
+            .make()
+            .getBytes();
+
+    ZipInputStream in = new ZipInputStream(new FileInputStream(jarFile));
+    ZipOutputStream zout = new ZipOutputStream(new FileOutputStream("tmp.jar"));
+
+    ZipEntry entry;
+    while ((entry = in.getNextEntry()) != null) {
+      if (entry
+          .getName()
+          .equals("inst/io/opentelemetry/javaagent/tooling/HelperInjector.classdata")) continue;
+      zout.putNextEntry(entry);
+      StaticInstrumenter.copy(in, zout);
+      zout.closeEntry();
+    }
+
+    ZipEntry newEntry =
+        new ZipEntry("inst/io/opentelemetry/javaagent/tooling/HelperInjector.classdata");
+    newEntry.setSize(helperInjectorBytes.length);
+    newEntry.setCompressedSize(-1);
+    zout.putNextEntry(newEntry);
+
+    StaticInstrumenter.copy(new ByteArrayInputStream(helperInjectorBytes), zout);
+    zout.closeEntry();
+
+    zout.close();
+    in.close();
+
+    Files.copy(Paths.get("tmp.jar"), jarFile.toPath(), REPLACE_EXISTING);
   }
 
   public void injectClasses(File jarFile) throws IOException {

--- a/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/advices/HelperInjectorAdvice.java
+++ b/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/advices/HelperInjectorAdvice.java
@@ -1,0 +1,18 @@
+package agh.edu.pl.agent.instrumentation.advices;
+
+import io.opentelemetry.javaagent.StaticInstrumenter;
+import net.bytebuddy.asm.Advice;
+
+import java.util.Map;
+
+public class HelperInjectorAdvice {
+
+  @Advice.OnMethodEnter(suppress = Throwable.class)
+  static void enter(@Advice.Argument(value = 0) Map<String, byte[]> classnameToBytes) {
+
+    for (String className : classnameToBytes.keySet()) {
+      String modifiedClassName = className.replace(".", "/") + ".class";
+      StaticInstrumenter.AdditionalClasses.put(modifiedClassName, classnameToBytes.get(className));
+    }
+  }
+}

--- a/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/advices/HelperInjectorAdvice.java
+++ b/agent-instrumenter/src/main/java/agh/edu/pl/agent/instrumentation/advices/HelperInjectorAdvice.java
@@ -1,9 +1,8 @@
 package agh.edu.pl.agent.instrumentation.advices;
 
 import io.opentelemetry.javaagent.StaticInstrumenter;
-import net.bytebuddy.asm.Advice;
-
 import java.util.Map;
+import net.bytebuddy.asm.Advice;
 
 public class HelperInjectorAdvice {
 

--- a/app-instrumenter/src/main/java/agh/edu/pl/repackaging/config/InstrumentationConstants.java
+++ b/app-instrumenter/src/main/java/agh/edu/pl/repackaging/config/InstrumentationConstants.java
@@ -11,6 +11,7 @@ public class InstrumentationConstants {
     return new ProcessBuilder(
         "java",
         "-Dota.static.instrumenter=true",
+        "-Dotel.instrumentation.internal-class-loader.enabled=false",
         String.format("-javaagent:%s", agentPath),
         "-cp",
         String.format("%s", classpath),

--- a/app-instrumenter/src/main/java/agh/edu/pl/repackaging/config/InstrumentationConstants.java
+++ b/app-instrumenter/src/main/java/agh/edu/pl/repackaging/config/InstrumentationConstants.java
@@ -11,9 +11,6 @@ public class InstrumentationConstants {
     return new ProcessBuilder(
         "java",
         "-Dota.static.instrumenter=true",
-        "-Dotel.javaagent.experimental.field-injection.enabled=false",
-        "-Dotel.instrumentation.logback.enabled=false",
-        "-Dotel.instrumentation.netty.enabled=false",
         String.format("-javaagent:%s", agentPath),
         "-cp",
         String.format("%s", classpath),


### PR DESCRIPTION
Javaagent generates some helper classes - so far, we ignored them, but now we are adding them via `StaticInstrumenter`.
This is achieved by instrumenting agent's `HelperInjector` class. We intercept `injectBootstrapClassLoader` so that it passes its classes to `StaticInstrumenter`.

Unfortunately, due to HelperInjector being located in `inst` and having a `.classdata` extension, loading the class and injecting it back into the jar requires additional steps and is not as efficient as it could be.